### PR TITLE
feat: lock out help on reset password page

### DIFF
--- a/theme/src/login/KcPage.tsx
+++ b/theme/src/login/KcPage.tsx
@@ -11,6 +11,8 @@ const UserProfileFormFields = lazy(
 
 const doMakeUserConfirmPassword = true;
 
+const LoginResetPassword = lazy(() => import("./pages/LoginResetPassword"));
+
 export default function KcPage(props: { kcContext: KcContext }) {
     const { kcContext } = props;
 
@@ -20,6 +22,13 @@ export default function KcPage(props: { kcContext: KcContext }) {
         <Suspense>
             {(() => {
                 switch (kcContext.pageId) {
+                    case "login-reset-password.ftl": return (
+                            <LoginResetPassword
+                                {...{ kcContext, i18n, classes }}
+                                Template={Template}
+                                doUseDefaultCss={true}
+                            />
+                        );
                     default:
                         return (
                             <DefaultPage

--- a/theme/src/login/i18n.ts
+++ b/theme/src/login/i18n.ts
@@ -3,7 +3,15 @@ import type { ThemeName } from "../kc.gen";
 
 /** @see: https://docs.keycloakify.dev/i18n */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const { useI18n, ofTypeI18n } = i18nBuilder.withThemeName<ThemeName>().build();
+const { useI18n, ofTypeI18n } = i18nBuilder
+    .withThemeName<ThemeName>()
+    .withCustomTranslations({
+        en: {
+            contactHelpMsg: "Locked out? Contact the",
+            contactHelpName: "secretary",
+        }
+    })
+    .build();
 
 type I18n = typeof ofTypeI18n;
 

--- a/theme/src/login/pages/LoginResetPassword.stories.tsx
+++ b/theme/src/login/pages/LoginResetPassword.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { createKcPageStory } from "../KcPageStory";
+
+const { KcPageStory } = createKcPageStory({ pageId: "login-reset-password.ftl" });
+
+const meta = {
+    title: "login/login-reset-password.ftl",
+    component: KcPageStory
+} satisfies Meta<typeof KcPageStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <KcPageStory/>
+    )
+};
+
+export const WithEmailAsUsername: Story = {
+    render: () => (
+        <KcPageStory
+            kcContext={{
+                realm: {
+                    loginWithEmailAllowed: true,
+                    registrationEmailAsUsername: true
+                }
+            }}
+        />
+    )
+};
+/**
+ * WithUsernameError:
+ * - Purpose: Tests behavior when an error occurs with the username input (e.g., invalid username).
+ * - Scenario: The component displays an error message next to the username input field.
+ * - Key Aspect: Ensures the username input shows error messages when validation fails.
+ */
+export const WithUsernameError: Story = {
+    render: () => (
+        <KcPageStory
+            kcContext={{
+                realm: {
+                    loginWithEmailAllowed: false,
+                    registrationEmailAsUsername: false,
+                    duplicateEmailsAllowed: false
+                },
+                url: {
+                    loginAction: "/mock-login-action",
+                    loginUrl: "/mock-login-url"
+                },
+                messagesPerField: {
+                    existsError: (field: string) => field === "username",
+                    get: () => "Invalid username",
+                },
+                auth: {
+                    attemptedUsername: "invalid_user"
+                },
+                
+            }}
+        />
+    )
+};

--- a/theme/src/login/pages/LoginResetPassword.tsx
+++ b/theme/src/login/pages/LoginResetPassword.tsx
@@ -1,0 +1,91 @@
+import { getKcClsx } from "keycloakify/login/lib/kcClsx";
+import { kcSanitize } from "keycloakify/lib/kcSanitize";
+import type { PageProps } from "keycloakify/login/pages/PageProps";
+import type { KcContext } from "../KcContext";
+import type { I18n } from "../i18n";
+
+export default function LoginResetPassword(props: PageProps<Extract<KcContext, { pageId: "login-reset-password.ftl" }>, I18n>) {
+    const { kcContext, i18n, doUseDefaultCss, Template, classes } = props;
+
+    const { kcClsx } = getKcClsx({
+        doUseDefaultCss,
+        classes
+    });
+
+    const { url, realm, auth, messagesPerField } = kcContext;
+
+    const { msg, msgStr } = i18n;
+
+    return (
+        <Template
+            kcContext={kcContext}
+            i18n={i18n}
+            doUseDefaultCss={doUseDefaultCss}
+            classes={classes}
+            displayInfo
+            displayMessage={!messagesPerField.existsError("username")}
+            infoNode={realm.duplicateEmailsAllowed ? msg("emailInstructionUsername") : <span>
+                {msg("emailInstruction")}
+                <br />
+                <br />
+                {msg("contactHelpMsg")} <a className={"!ml-0"} href="mailto:sec@bts-crew.com">{msg("contactHelpName")}</a>
+
+            </span>
+            }
+            headerNode={msg("emailForgotTitle")}
+        >
+            <form id="kc-reset-password-form" className={kcClsx("kcFormClass")} action={url.loginAction} method="post">
+                <div className={kcClsx("kcFormGroupClass")}>
+                    <div className={kcClsx("kcLabelWrapperClass")}>
+                        <label htmlFor="username" className={kcClsx("kcLabelClass")}>
+                            {!realm.loginWithEmailAllowed
+                                ? msg("username")
+                                : !realm.registrationEmailAsUsername
+                                  ? msg("usernameOrEmail")
+                                  : msg("email")}
+                        </label>
+                    </div>
+                    
+                    <div className={kcClsx("kcInputWrapperClass")}>
+                        <input
+                            type="text"
+                            id="username"
+                            name="username"
+                            className={kcClsx("kcInputClass")}
+                            autoFocus
+                            defaultValue={auth.attemptedUsername ?? ""}
+                            aria-invalid={messagesPerField.existsError("username")}
+                        />
+                        {messagesPerField.existsError("username") && (
+                            <span
+                                id="input-error-username"
+                                className={kcClsx("kcInputErrorMessageClass")}
+                                aria-live="polite"
+                                dangerouslySetInnerHTML={{
+                                    __html: kcSanitize(messagesPerField.get("username"))
+                                }}
+                            />
+                        )}
+                    </div>
+                </div>
+                <div className={kcClsx("kcFormGroupClass", "kcFormSettingClass")}>
+                    <div id="kc-form-options" className={kcClsx("kcFormOptionsClass")}>
+                        <div className={kcClsx("kcFormOptionsWrapperClass")}>
+                            <span>
+                                <a href={url.loginUrl}>{msg("backToLogin")}</a>
+                            </span>
+                        </div>
+                    </div>
+
+                    <div id="kc-form-buttons" className={kcClsx("kcFormButtonsClass")}>
+                        <input
+                            className={kcClsx("kcButtonClass", "kcButtonPrimaryClass", "kcButtonBlockClass", "kcButtonLargeClass")}
+                            type="submit"
+                            value={msgStr("doSubmit")}
+                        />
+                    </div>
+                </div>
+            </form>
+        </Template>
+    );
+}


### PR DESCRIPTION
<!-- PLEASE COMPLETE THIS TO THE BEST OF YOUR ABILITY -->

<!-- NOTE: your PR title will need to conform to the conventional commit spec -->

### Description

Adds text to the info wrapper to email the secretary if a user can't access their account. 

Feels unnecessary to eject the page... feel free to voice alternative approaches 

