### PR TITLE
feat: increase sso session durations

### DIFF
--- a/terraform/modules/realm/main.tf
+++ b/terraform/modules/realm/main.tf
@@ -22,9 +22,13 @@ resource "keycloak_realm" "default" {
   # Authentication settings
   password_policy = "notUsername and notEmail and notContainsUsername and passwordHistory(3) and length(5)"
 
-  # Tokens
-  access_token_lifespan    = var.access_token_lifespan
-  sso_session_idle_timeout = var.sso_session_idle_timeout
+  # Sessions
+  access_token_lifespan                = var.access_token_lifespan
+  sso_session_idle_timeout             = "${7 * 24}h"
+  sso_session_max_lifespan             = "${14 * 24}h"
+  sso_session_idle_timeout_remember_me = "${30 * 24}h"
+  sso_session_max_lifespan_remember_me = "${90 * 24}h"
+  offline_session_idle_timeout         = "${30 * 24}h"
 
   # Security
   security_defenses {

--- a/terraform/modules/realm/variables.tf
+++ b/terraform/modules/realm/variables.tf
@@ -20,10 +20,5 @@ variable "use_custom_auth_flows" {
 
 // Token config
 variable "access_token_lifespan" {
-  type    = string
-  default = "5m"
-}
-variable "sso_session_idle_timeout" {
-  type    = string
-  default = "30m"
+  type = string
 }

--- a/terraform/realms/nonprod/main.tf
+++ b/terraform/realms/nonprod/main.tf
@@ -13,6 +13,5 @@ module "realm" {
   name         = "nonprod"
   display_name = "Backstage (NonProd)"
 
-  access_token_lifespan    = "8h"
-  sso_session_idle_timeout = "8h"
+  access_token_lifespan = "8h"
 }

--- a/terraform/realms/prod/main.tf
+++ b/terraform/realms/prod/main.tf
@@ -12,4 +12,6 @@ module "realm" {
 
   name         = "prod"
   display_name = "Backstage"
+
+  access_token_lifespan = "5m"
 }


### PR DESCRIPTION
<!-- PLEASE COMPLETE THIS TO THE BEST OF YOUR ABILITY -->

<!-- NOTE: your PR title will need to conform to the conventional commit spec -->

### Description

Increases the session settings so that auth sessions remain active for longer:

- SSO Session Idle: 7d
- SSO Session Max: 14d
- SSO Session Idle Remember Me: 30d
- SSO Session Max Remember Me: 90d
- Offline Session Idle: 30d

Resolves #8

### Checklist

> [!IMPORTANT]
> Make sure you follow these wherever possible; if you have then check it off, and if not then use a strikethrough (\~)
> to cross it off. This will help the reviewer identify any changes that may have been missed.

* [ ] Documentation updated/written (if applicable)
* [ ] DRY, SOLID and Clean
* [ ] Follows language code style
* [ ] Use consistent vocabulary
* [ ] Any tech debt justified and ticketed where appropriate
