### PR TITLE
feat: remove restrict_access from wiki + nextcloud

### DIFF
--- a/terraform/realms/prod/clients.tf
+++ b/terraform/realms/prod/clients.tf
@@ -33,9 +33,9 @@ module "website_v4_client" {
 module "wiki_client" {
   source = "../../modules/oidc-client"
 
-  realm           = module.realm
-  client_id       = "wiki"
-  name            = "Wiki"
+  realm     = module.realm
+  client_id = "wiki"
+  name      = "Wiki"
 
   enabled_flows = {
     authorization_code = true
@@ -53,9 +53,9 @@ module "wiki_client" {
 module "nextcloud_client" {
   source = "../../modules/oidc-client"
 
-  realm           = module.realm
-  client_id       = "nextcloud"
-  name            = "Nextcloud"
+  realm     = module.realm
+  client_id = "nextcloud"
+  name      = "Nextcloud"
 
   enabled_flows = {
     authorization_code = true

--- a/terraform/realms/prod/clients.tf
+++ b/terraform/realms/prod/clients.tf
@@ -36,7 +36,6 @@ module "wiki_client" {
   realm           = module.realm
   client_id       = "wiki"
   name            = "Wiki"
-  restrict_access = true
 
   enabled_flows = {
     authorization_code = true
@@ -57,7 +56,6 @@ module "nextcloud_client" {
   realm           = module.realm
   client_id       = "nextcloud"
   name            = "Nextcloud"
-  restrict_access = true
 
   enabled_flows = {
     authorization_code = true


### PR DESCRIPTION
Removed 'restrict_access' property from Wiki and Nextcloud clients.

<!-- PLEASE COMPLETE THIS TO THE BEST OF YOUR ABILITY -->

<!-- NOTE: your PR title will need to conform to the conventional commit spec -->

### Description

Temporarily disable restricted access on the Wiki and Nextcloud until it's configured properly 

### Checklist

> [!IMPORTANT]
> Make sure you follow these wherever possible; if you have then check it off, and if not then use a strikethrough (\~)
> to cross it off. This will help the reviewer identify any changes that may have been missed.

* [ ] Documentation updated/written (if applicable)
* [ ] DRY, SOLID and Clean
* [ ] Follows language code style
* [ ] Use consistent vocabulary
* [ ] Any tech debt justified and ticketed where appropriate
